### PR TITLE
added support for PUT/PATCH data

### DIFF
--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -285,11 +285,11 @@ class HttpRequest implements Request
 
     private function parseInputParameters()
     {
-        if ($this->getMethod() == 'PUT' || $this->getMethod() == 'PATCH') {
-            if ($this->getServerVariable('HTTP_CONTENT_TYPE') == 'application/x-www-form-urlencoded') {
+        if (($this->getMethod() == 'PUT' || $this->getMethod() == 'PATCH') && isset($this->server['HTTP_CONTENT_TYPE'])) {
+            if ($this->server['HTTP_CONTENT_TYPE'] == 'application/x-www-form-urlencoded') {
                 parse_str($this->inputStream, $this->postParameters);
             }
-            else if ($this->getServerVariable('HTTP_CONTENT_TYPE') == 'application/json') {
+            else if ($this->server['HTTP_CONTENT_TYPE'] == 'application/json') {
                 $this->postParameters = json_decode($this->inputStream, true);
             }
         }

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -285,13 +285,16 @@ class HttpRequest implements Request
 
     private function parseInputParameters()
     {
-        if (($this->getMethod() == 'PUT' || $this->getMethod() == 'PATCH') && isset($this->server['HTTP_CONTENT_TYPE'])) {
+        if (isset($this->server['REQUEST_METHOD']) && isset($this->server['HTTP_CONTENT_TYPE']) &&
+            ($this->getMethod() == 'PUT' || $this->getMethod() == 'PATCH'))
+        {
             if ($this->server['HTTP_CONTENT_TYPE'] == 'application/x-www-form-urlencoded') {
                 parse_str($this->inputStream, $this->postParameters);
             }
             else if ($this->server['HTTP_CONTENT_TYPE'] == 'application/json') {
                 $this->postParameters = json_decode($this->inputStream, true);
             }
+
         }
     }
 }

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -9,6 +9,7 @@ class HttpRequest implements Request
     protected $server;
     protected $files;
     protected $cookies;
+    protected $inputStream;
 
     public function __construct(
         array $get,
@@ -24,6 +25,8 @@ class HttpRequest implements Request
         $this->files = $files;
         $this->server = $server;
         $this->inputStream = $inputStream;
+
+        $this->parseInputParameters();
     }
 
     /**
@@ -141,10 +144,10 @@ class HttpRequest implements Request
     }
 
     /**
-    * Returns raw values from the read-only stream that allows you to read raw data from the request body.
-    *
-    * @return string
-    */
+     * Returns raw values from the read-only stream that allows you to read raw data from the request body.
+     *
+     * @return string
+     */
     public function getRawBody()
     {
         return $this->inputStream;
@@ -278,5 +281,17 @@ class HttpRequest implements Request
         }
 
         return $this->server[$key];
+    }
+
+    private function parseInputParameters()
+    {
+        if ($this->getMethod() == 'PUT' || $this->getMethod() == 'PATCH') {
+            if ($this->getServerVariable('HTTP_CONTENT_TYPE') == 'application/x-www-form-urlencoded') {
+                parse_str($this->inputStream, $this->postParameters);
+            }
+            else if ($this->getServerVariable('HTTP_CONTENT_TYPE') == 'application/json') {
+                $this->postParameters = json_decode($this->inputStream, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
I've tried using your HTTP component for simple REST API in PHP. However when i tried working with PATCH/PUT requests, i've found that it doesn't retrieve data from those because PHP doesn't automatically put the data like it does for GET/POST in $_GET/$_POST. After that i've moved on to try few other HTTP packages and to my surprise not a single one of them supported this.

So i've done some experimenting and i believe that this is the right way to parse data in these cases. 

Let me know your thoughts
