### PR TITLE
added support for json responses

### DIFF
--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -173,12 +173,12 @@ class HttpResponse implements Response
     /**
      * Sets the body content.
      *
-     * @param  string $content
+     * @param  string|array $content
      * @return void
      */
     public function setContent($content)
     {
-        $this->content = (string) $content;
+        $this->content = $content;
     }
 
     /**
@@ -188,7 +188,11 @@ class HttpResponse implements Response
      */
     public function getContent()
     {
-        return $this->content;
+        if (isset($this->headers['Content-Type']) && $this->headers['Content-Type'][0] == "application/json") {
+            return json_encode($this->content);
+        }
+        else
+            return (string) $this->content;
     }
 
     /**


### PR DESCRIPTION
With this modification, you can now return JSON responses just by setting the appropriate response header.

I think it's useful for cases like in your no-framework tutorial where we have a single point of response return (in Bootstrap.php) file and all i do there is 

```
$response->setHeader('Content-Type', 'application/json');
echo $response->getContent();
```

while in all the other Controllers/Handlers i can just set array as a response body

```
...
$response->setContent(['user' => 'example']);
...
```
