### PR TITLE
add a public method send to avoid code duplicates

### DIFF
--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -202,6 +202,21 @@ class HttpResponse implements Response
         $this->setHeader('Location', $url);
         $this->setStatusCode(301);
     }
+    
+    /**
+     * Sends the headers and content
+     *
+     * @codeCoverageIgnore This function can not be tested because it uses native php functions
+     * @return void
+     */
+    public function send() 
+    {
+        foreach ($response->getHeaders() as $header) {
+            header($header);
+        }
+
+        echo $response->getContent();
+    }
 
     private function getRequestLineHeaders()
     {

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -211,11 +211,11 @@ class HttpResponse implements Response
      */
     public function send() 
     {
-        foreach ($response->getHeaders() as $header) {
+        foreach ($this->getHeaders() as $header) {
             header($header);
         }
 
-        echo $response->getContent();
+        echo $this->getContent();
     }
 
     private function getRequestLineHeaders()


### PR DESCRIPTION
Currently everyone using this response object has to write the code in his front controller. Instead we should give him this option - even if it is not testable.