### PR TITLE
Http library moderinsation

### DIFF
--- a/.github/workflows/push-run-test-suite.yml
+++ b/.github/workflows/push-run-test-suite.yml
@@ -13,7 +13,6 @@ jobs:
           php-version: 8.2
           coverage: none
           tools: composer:v2
-      - name: Set
       - name: Install dependencies
         run: composer install --dev --no-interaction
       - name: Create build directory

--- a/.github/workflows/push-run-test-suite.yml
+++ b/.github/workflows/push-run-test-suite.yml
@@ -1,0 +1,28 @@
+name: push-run-test-suite
+run-name: ${{ github.event.repository.name }} ${{ github.event.ref }} ${{ github.event.head_commit.message }} run test suite.
+on: [push]
+jobs:
+  run-test-suite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v3
+        with:
+          php-version: 8.2
+          coverage: none
+          tools: composer:v2
+      - name: Set
+      - name: Install dependencies
+        run: composer install --dev --no-interaction
+      - name: Create build directory
+        run: mkdir -p build/logs
+      - name: Run test suite
+        run: ./vendor/bin/phpunit --bootstrap vendor/autoload.php --coverage-clover build/logs/clover.xml test
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: build/logs/clover.xml
+  

--- a/.github/workflows/push-run-test-suite.yml
+++ b/.github/workflows/push-run-test-suite.yml
@@ -11,7 +11,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
-          coverage: none
+          coverage: xdebug
           tools: composer:v2
       - name : Install php-coveralls
         run: composer require php-coveralls/php-coveralls:~2.5

--- a/.github/workflows/push-run-test-suite.yml
+++ b/.github/workflows/push-run-test-suite.yml
@@ -13,6 +13,8 @@ jobs:
           php-version: 8.2
           coverage: none
           tools: composer:v2
+      - name : Install php-coveralls
+        run: composer require php-coveralls/php-coveralls:~2.5
       - name: Install dependencies
         run: composer install --dev --no-interaction
       - name: Create build directory

--- a/.github/workflows/push-run-test-suite.yml
+++ b/.github/workflows/push-run-test-suite.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup PHP
-        uses: shivammathur/setup-php@v3
+        uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
           coverage: none

--- a/.github/workflows/push-run-test-suite.yml
+++ b/.github/workflows/push-run-test-suite.yml
@@ -14,7 +14,7 @@ jobs:
           coverage: xdebug
           tools: composer:v2
       - name : Install php-coveralls
-        run: composer require php-coveralls/php-coveralls:~2.5
+        run: composer global require php-coveralls/php-coveralls:~2.5
       - name: Install dependencies
         run: composer install --dev --no-interaction
       - name: Create build directory
@@ -22,8 +22,8 @@ jobs:
       - name: Run test suite
         run: ./vendor/bin/phpunit --bootstrap vendor/autoload.php --coverage-clover build/logs/clover.xml test
       - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: build/logs/clover.xml
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          php-coveralls --coverage_clover=build/logs/clover.xml -v
   

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 .idea
 .phpunit.cache
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 composer.lock
 .idea
+.phpunit.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 php:
-  - "5.5"
+  - "8.2"
 
 install:
-  - composer require satooshi/php-coveralls:~0.6@stable
+  - composer require php-coveralls/php-coveralls:~2.5
  
 before_script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.0.*"
+        "phpunit/phpunit": "^10"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="true"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -9,6 +9,7 @@ class HttpRequest implements Request
     protected $server;
     protected $files;
     protected $cookies;
+    protected $inputStream;
 
     public function __construct(
         array $get,
@@ -16,7 +17,7 @@ class HttpRequest implements Request
         array $cookies,
         array $files,
         array $server,
-        $inputStream = ''
+        string $inputStream = ''
     ) {
         $this->getParameters = $get;
         $this->postParameters = $post;

--- a/test/Unit/CookieBuilderTest.php
+++ b/test/Unit/CookieBuilderTest.php
@@ -4,7 +4,7 @@ namespace Http\Test\Unit;
 
 use Http\CookieBuilder;
 
-class CookieBuilderTest extends \PHPUnit_Framework_TestCase
+class CookieBuilderTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetDefaultDomain()
     {

--- a/test/Unit/CookieBuilderTest.php
+++ b/test/Unit/CookieBuilderTest.php
@@ -4,6 +4,10 @@ namespace Http\Test\Unit;
 
 use Http\CookieBuilder;
 
+/**
+ * @covers Http\CookieBuilder
+ * @covers Http\HttpCookie
+ */
 class CookieBuilderTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetDefaultDomain()

--- a/test/Unit/HttpCookieTest.php
+++ b/test/Unit/HttpCookieTest.php
@@ -4,7 +4,7 @@ namespace Http\Test\Unit;
 
 use Http\HttpCookie;
 
-class HttpCookieTest extends \PHPUnit_Framework_TestCase
+class HttpCookieTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetName()
     {

--- a/test/Unit/HttpCookieTest.php
+++ b/test/Unit/HttpCookieTest.php
@@ -4,6 +4,9 @@ namespace Http\Test\Unit;
 
 use Http\HttpCookie;
 
+/**
+ * @covers Http\HttpCookie
+ */
 class HttpCookieTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetName()

--- a/test/Unit/HttpRequestTest.php
+++ b/test/Unit/HttpRequestTest.php
@@ -4,6 +4,10 @@ namespace Http\Test\Unit;
 
 use Http\HttpRequest;
 
+/**
+ * @covers Http\HttpRequest
+ * @uses Http\MissingRequestMetaVariableException
+ */
 class HttpRequestTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetParameter()

--- a/test/Unit/HttpRequestTest.php
+++ b/test/Unit/HttpRequestTest.php
@@ -4,7 +4,7 @@ namespace Http\Test\Unit;
 
 use Http\HttpRequest;
 
-class HttpRequestTest extends \PHPUnit_Framework_TestCase
+class HttpRequestTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetParameter()
     {
@@ -241,11 +241,9 @@ class HttpRequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Http\MissingRequestMetaVariableException
-     */
     public function testGetMethodException()
     {
+        $this->expectException(\Http\MissingRequestMetaVariableException::class);
         $request = new HttpRequest([], [], [], [], []);
         $request->getMethod();
     }
@@ -271,11 +269,9 @@ class HttpRequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Http\MissingRequestMetaVariableException
-     */
     public function testGetUriException()
     {
+        $this->expectException(\Http\MissingRequestMetaVariableException::class);
         $request = new HttpRequest([], [], [], [], []);
         $request->getUri();
     }
@@ -313,11 +309,9 @@ class HttpRequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Http\MissingRequestMetaVariableException
-     */
     public function testGetHttpAcceptException()
     {
+        $this->expectException(\Http\MissingRequestMetaVariableException::class);
         $request = new HttpRequest([], [], [], [], []);
         $request->getHttpAccept();
     }
@@ -334,11 +328,9 @@ class HttpRequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Http\MissingRequestMetaVariableException
-     */
     public function testGetRefererException()
     {
+        $this->expectException(\Http\MissingRequestMetaVariableException::class);
         $request = new HttpRequest([], [], [], [], []);
         $request->getReferer();
     }
@@ -355,11 +347,9 @@ class HttpRequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Http\MissingRequestMetaVariableException
-     */
     public function testGetUserAgentException()
     {
+        $this->expectException(\Http\MissingRequestMetaVariableException::class);
         $request = new HttpRequest([], [], [], [], []);
         $request->getUserAgent();
     }
@@ -376,11 +366,9 @@ class HttpRequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Http\MissingRequestMetaVariableException
-     */
     public function testGetIpAddressException()
     {
+        $this->expectException(\Http\MissingRequestMetaVariableException::class);
         $request = new HttpRequest([], [], [], [], []);
         $request->getIpAddress();
     }
@@ -409,11 +397,9 @@ class HttpRequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Http\MissingRequestMetaVariableException
-     */
     public function testGetQueryStringException()
     {
+        $this->expectException(\Http\MissingRequestMetaVariableException::class);
         $request = new HttpRequest([], [], [], [], []);
         $request->getQueryString();
     }

--- a/test/Unit/HttpResponseTest.php
+++ b/test/Unit/HttpResponseTest.php
@@ -4,7 +4,7 @@ namespace Http\Test\Unit;
 
 use Http\HttpResponse;
 
-class HttpResponseTest extends \PHPUnit_Framework_TestCase
+class HttpResponseTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetStatusCode()
     {

--- a/test/Unit/HttpResponseTest.php
+++ b/test/Unit/HttpResponseTest.php
@@ -4,6 +4,9 @@ namespace Http\Test\Unit;
 
 use Http\HttpResponse;
 
+/**
+ * @covers Http\HttpResponse
+ */
 class HttpResponseTest extends \PHPUnit\Framework\TestCase
 {
     public function testSetStatusCode()


### PR DESCRIPTION
This pull request started out as a fix for the 8.2 deprecation error but ended up having additional changes:

- Fix deprecation error in HttpRequest
- Updated unit tests to include coverage tags
- Implemented Github actions instead of Travis CI as it has been retired